### PR TITLE
PF-33 product/:id devuelve un array con un solo elemento

### DIFF
--- a/src/controllers/product.js
+++ b/src/controllers/product.js
@@ -22,7 +22,7 @@ const getAllProducts = async (req, res) => {
 
 const getProduct = async (req, res) => {
   try {
-    const products = await Product.find({
+    const products = await Product.findOne({
       _id: req.params.id,
       deleted: { $ne: true },
     });


### PR DESCRIPTION
### Cambios:
- Controlador getProduct: El método .find() paso a .findOne() para que en vez de devolver un array devuelva un objeto.

### Imágenes:
- Ahora devuelve un objeto.
![image](https://github.com/jdelaiglesia/pf-backend/assets/128014396/066630ac-8ec7-469a-bb6a-37a7fc44a4d7)
